### PR TITLE
PM deliverables — repo index, snapshot objectives, risk register

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,42 @@
+# macOS junk
+.DS_Store
+**/.DS_Store
+
+# LaTeX build artifacts
+*.aux
+*.log
+*.out
+*.toc
+*.synctex.gz
+*.fls
+*.fdb_latexmk
+*.lof
+*.lot
+*.bbl
+*.blg
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+
+# Node
+node_modules/
+dist/
+.next/
+
+# IDE
+.vscode/
+.idea/
+
+# Storage of large binary scans (do not commit)
+Final_Project/storage/raw/*
+Final_Project/storage/processed/*
+Final_Project/storage/models/*
+
+# Lab leftovers we are intentionally keeping out of git
+Final_Project/src/logs/access.log
+Final_Project/src/logs/debug.log
+Final_Project/src/logs/error.log

--- a/Final_Project/admin/meeting_notes/TEMPLATE.md
+++ b/Final_Project/admin/meeting_notes/TEMPLATE.md
@@ -1,0 +1,68 @@
+# Meeting Notes — Group 5
+
+**Date:** YYYY-MM-DD
+**Sprint / Snapshot:** S?
+**Type:** Sprint Planning / Standup / Retro / Ad-hoc
+**Facilitator:** Erfan Mirzaee
+**Note-taker:** _____
+
+## Attendance
+
+- [ ] Erfan Mirzaee
+- [ ] James Barron
+- [ ] Elijah Rodriguez
+- [ ] Andrew
+- [ ] Darien Amador
+
+## Agenda
+
+1.
+2.
+3.
+
+## Status by Owner (round-robin)
+
+### Erfan (PM)
+- Done since last meeting:
+- Doing this week:
+- Blockers:
+
+### James (SRS)
+- Done:
+- Doing:
+- Blockers:
+
+### Elijah (SDD / Workflow)
+- Done:
+- Doing:
+- Blockers:
+
+### Andrew (Design Spec / Docker)
+- Done:
+- Doing:
+- Blockers:
+
+### Darien (README / TestRail)
+- Done:
+- Doing:
+- Blockers:
+
+## Decisions
+
+| # | Decision | Owner | Due |
+|---|---|---|---|
+
+## Action Items
+
+| # | Action | Owner | Due | Jira ID |
+|---|---|---|---|---|
+
+## Risks Discussed
+
+| ID | Update |
+|---|---|
+
+## Next Meeting
+
+**Date:**
+**Pre-reads:**

--- a/Final_Project/admin/risk_register.md
+++ b/Final_Project/admin/risk_register.md
@@ -1,0 +1,33 @@
+# Risk Register — CS 3338 LA City Sidewalk Assessment
+
+**Owner:** Erfan Mirzaee (PM)
+**Update cadence:** End of each snapshot, plus on any new bug filed in Jira.
+
+Likelihood × Impact = Score (1=low, 5=high). Re-score every snapshot.
+
+| ID | Risk | Likelihood | Impact | Score | Owner | Mitigation | Status |
+|---|---|---|---|---|---|---|---|
+| R-01 | LiDAR scan import fails (LAS/PLY format quirks) | 4 | 4 | 16 | Andrew | Pin Laspy + Open3D versions; document supported formats in Design Spec. | Open |
+| R-02 | Mask and DEM resolution mismatch produces bad displacement values | 3 | 5 | 15 | Andrew | Add validation step in SDD that asserts shape parity before displacement calc. | Open |
+| R-03 | Missing Docker dependency at build time | 3 | 3 | 9 | Andrew | Run `docker compose config` in CI on every PR. | Open |
+| R-04 | GPS waypoint drift causes navigation to skip stops | 4 | 4 | 16 | Elijah | SRS requires telemetry log + manual override; TestRail safety suite. | Open |
+| R-05 | Obstacle detection false positive triggers safe-stop too often | 3 | 3 | 9 | Elijah | Document tunable confidence threshold in Design Spec. | Open |
+| R-06 | README setup instructions incomplete (graders cannot run repo) | 4 | 5 | 20 | Darien | Pre-submission audit step: another teammate clones in incognito + follows README verbatim. | Open |
+| R-07 | LaTeX files don't compile on grader's machine | 3 | 4 | 12 | Erfan | Pin to `pdflatex` standard packages only; commit a compiled PDF alongside `.tex` for backup. | Open |
+| R-08 | One team member falls behind; snapshot blocked | 2 | 5 | 10 | Erfan | Weekly standup; snapshot mid-checkpoint at week 6 of each 12-week block. | Open |
+| R-09 | Jira board access lost / org admin issue | 1 | 4 | 4 | Erfan | Export Jira issues to CSV at end of each snapshot, commit to `admin/jira_exports/`. | Open |
+| R-10 | TestRail trial expires before Snapshot 4 | 2 | 4 | 8 | Darien | Confirm trial duration; have export PDF habit so loss of access doesn't lose work. | Open |
+| R-11 | Team using `.docx` instead of required `.tex` files | 5 | 4 | 20 | Erfan | Flag at sprint planning; document owners must convert their placeholders to `.tex` in S1. | Open |
+| R-12 | `.gitignore` excludes deliverables (e.g., `docs/User_Manual/`) | 5 | 5 | 25 | Erfan | Fix in S1; review every snapshot. | Resolved S1 |
+
+## Snapshot 2 Update
+
+_To be completed at end of Snapshot 2._
+
+## Snapshot 3 Update
+
+_To be completed at end of Snapshot 3._
+
+## Snapshot 4 Update
+
+_To be completed at end of Snapshot 4._

--- a/Final_Project/docs/Snapshot_Objectives/Snapshot_Objectives.tex
+++ b/Final_Project/docs/Snapshot_Objectives/Snapshot_Objectives.tex
@@ -1,0 +1,298 @@
+\documentclass[11pt]{article}
+\usepackage[margin=1in]{geometry}
+\usepackage{longtable}
+\usepackage{enumitem}
+\usepackage{hyperref}
+\usepackage{titlesec}
+\usepackage{xcolor}
+
+\hypersetup{
+  colorlinks=true,
+  linkcolor=blue,
+  urlcolor=blue
+}
+
+\title{CS 3338 Snapshot Objectives \\
+\large LA City Sidewalk Assessment Simulation}
+\author{Group 5 \\
+Erfan Mirzaee (Project Manager) \\
+James Barron, Elijah Rodriguez, Andrew, Darien Amador}
+\date{\today}
+
+\begin{document}
+\maketitle
+\tableofcontents
+\newpage
+
+%==========================================================
+\section{Document Control}
+%==========================================================
+
+\subsection{Revision History}
+\begin{longtable}{|p{1.2in}|p{0.9in}|p{0.7in}|p{2.8in}|}
+\hline
+\textbf{Author} & \textbf{Date} & \textbf{Version} & \textbf{Reason for Change} \\ \hline
+Erfan Mirzaee & ADD\_DATE & 1.0 & Initial Snapshot 1 plan: all four snapshot objectives drafted, definition of done for each. \\ \hline
+Erfan Mirzaee & ADD\_DATE & 2.0 & Snapshot 2 reflection added; risks re-scored. \\ \hline
+Erfan Mirzaee & ADD\_DATE & 3.0 & Snapshot 3 reflection added; navigation scope confirmed. \\ \hline
+Erfan Mirzaee & ADD\_DATE & 4.0 & Snapshot 4 final reflection, future work, retrospective. \\ \hline
+\end{longtable}
+
+\subsection{Project Links}
+\begin{itemize}[leftmargin=*]
+  \item GitHub Repository: \url{https://github.com/dar-ienn/CS3338-final-project}
+  \item Jira Board: \url{https://cs3338-group-5-final-project.atlassian.net/jira/software/projects/SCRUM/boards/1/backlog}
+  \item TestRail: \url{https://ercs3338group5.testrail.io}
+\end{itemize}
+
+\subsection{Project Summary}
+This project simulates a 12-month software development timeline for the
+LA City Sidewalk Assessment (Ascent) system. The system supports a
+rover-based sidewalk inspection workflow that collects LiDAR/point-cloud
+data, segments sidewalk joints and cracks using a U-Net deep learning
+model, measures vertical and horizontal displacement, and produces
+review-ready outputs for the LA City Bureau of Engineering (BOE) for
+ADA compliance assessment.
+
+The simulation is divided into four snapshots of approximately three
+simulated months each, with each snapshot adding a major capability:
+foundation, displacement pipeline, semi-autonomous navigation, and
+final delivery.
+
+\subsection{Repository Layout}
+All deliverables live under the existing \texttt{Final\_Project/} wrapper
+that the team established during the prerequisite lab. Required files
+and their paths:
+\begin{itemize}[leftmargin=*]
+  \item \texttt{Final\_Project/docs/Snapshot\_Objectives/Snapshot\_Objectives.tex}
+  \item \texttt{Final\_Project/docs/Software\_Requirement\_Specifications/SRS.tex}
+  \item \texttt{Final\_Project/docs/Software\_Design\_Document/SDD.tex}
+  \item \texttt{Final\_Project/docs/User\_Manual/README\_User\_Manual.tex}
+  \item \texttt{Final\_Project/docs/Workflow\_Diagram/Workflow\_Diagram.png}
+  \item \texttt{Final\_Project/docs/TestRail\_Documents/*.pdf} (four reports)
+  \item \texttt{Final\_Project/docker/docker-compose.yml}
+  \item \texttt{Final\_Project/admin/} (risk register, meeting notes)
+\end{itemize}
+
+%==========================================================
+\section{Snapshot 1 -- Project Foundation}
+%==========================================================
+\textit{Simulated Months 1--3.}
+
+\subsection{Objective}
+Establish the repository, Jira board, baseline architecture, and initial
+documentation for the LA City Sidewalk Assessment simulation. By the end
+of Snapshot 1 the project must be \textbf{organizationally complete} even
+though no major feature has been implemented: every required document
+exists at draft level, every team member has an assigned role, and the
+toolchain (GitHub, Jira, TestRail, Docker) is wired up.
+
+\subsection{Planned Work Items}
+\begin{itemize}[leftmargin=*]
+  \item \textbf{P1-S1-001} Reorganize and document the existing repo; fix \texttt{.gitignore}; add root README (Erfan).
+  \item \textbf{P1-S1-002} Create Jira project, epics, and Snapshot 1 sprint (Erfan).
+  \item \textbf{P1-S1-003} Draft \texttt{Snapshot\_Objectives.tex} covering all four snapshots (Erfan).
+  \item \textbf{P1-S1-004} Initialize risk register and meeting cadence (Erfan).
+  \item \textbf{P2-S1-001} Convert empty SRS \texttt{.docx} placeholders to a single \texttt{SRS.tex}; draft introduction, scope, user classes, FRs (James).
+  \item \textbf{P3-S1-001} Convert empty SDD \texttt{.docx} placeholders to a single \texttt{SDD.tex}; draft architecture overview and module list (Elijah).
+  \item \textbf{P3-S1-002} Replace the empty \texttt{project\_workflow\_diagram.png} with a real workflow diagram (Elijah).
+  \item \textbf{P4-S1-001} Draft \texttt{Design\_Spec.tex} and dependency list (Andrew).
+  \item \textbf{P4-S1-002} Add Docker compose draft and service Dockerfiles (Andrew).
+  \item \textbf{P5-S1-001} Convert empty \texttt{User\_Manual/README.md} placeholder to \texttt{README\_User\_Manual.tex} (Darien).
+  \item \textbf{P5-S1-002} Create manual test case template (Darien).
+  \item \textbf{TEAM-S1-001} Cross-review all Snapshot 1 documents.
+\end{itemize}
+
+\subsection{Definition of Done}
+\begin{itemize}[leftmargin=*]
+  \item Existing \texttt{Final\_Project/} structure is preserved.
+  \item All five required \texttt{.tex} files exist with at least skeleton content.
+  \item \texttt{docker/docker-compose.yml} exists and passes \texttt{docker compose config}.
+  \item Workflow diagram v1 (PNG + editable source) is committed.
+  \item Jira board has the eleven epics created and Snapshot 1 sprint populated.
+  \item Each team member has at least one merged pull request.
+  \item Risk register is initialized with the ten baseline risks.
+  \item \texttt{.gitignore} is fixed so it does not exclude required deliverables.
+\end{itemize}
+
+\subsection{Snapshot 1 Reflection}
+\textit{To be completed at end of Snapshot 1.}\\
+Completed: \dots \\
+Deferred: \dots \\
+Lessons learned: \dots
+
+%==========================================================
+\section{Snapshot 2 -- Data Processing and Displacement Pipeline}
+%==========================================================
+\textit{Simulated Months 4--6. First major technical feature.}
+
+\subsection{Objective}
+Document and simulate the data processing pipeline that turns raw LiDAR
+scans into displacement measurements. This is the highest-risk technical
+area of the project, so all design decisions and dependencies must be
+fully captured in the SRS, SDD, and Design Spec, and verified by a
+TestRail run.
+
+\subsection{Planned Work Items}
+\begin{itemize}[leftmargin=*]
+  \item \textbf{P2-S2-001} Update SRS with LAS/PLY import, orthoimage,
+        DEM, U-Net mask, vertical displacement, horizontal displacement
+        research, CSV export, and validation metric requirements.
+  \item \textbf{P3-S2-001} Update SDD with module interactions for raw
+        scan import, \texttt{PointCloud2OrthoImage} conversion, DEM
+        alignment, mask alignment, displacement CSV output, and
+        validation flow.
+  \item \textbf{P4-S2-001} Add full dependency list (Python 3.10,
+        TensorFlow/Keras, NumPy, Pandas, Pillow, SciPy, Matplotlib,
+        OpenCV, Laspy, Open3D) to Design Spec; update \texttt{ml-worker}
+        Docker service.
+  \item \textbf{P5-S2-001} Build TestRail suite for Documentation,
+        Data Import, Processing Pipeline, ML Segmentation, and
+        Displacement Calculation. Execute first run.
+  \item \textbf{P1-S2-001} Hold sprint retro, update risk register,
+        record reflection in this document (Erfan).
+\end{itemize}
+
+\subsection{Definition of Done}
+\begin{itemize}[leftmargin=*]
+  \item SRS lists FR-1 through at least FR-15 covering full pipeline.
+  \item SDD shows data flow from LAS/PLY $\rightarrow$ orthoimage + DEM
+        $\rightarrow$ U-Net mask $\rightarrow$ displacement CSV.
+  \item Design Spec lists every dependency with version and license.
+  \item Two TestRail PDFs committed in \texttt{Final\_Project/docs/TestRail\_Documents/}:
+        \texttt{Snapshot2\_TestRun\_Report.pdf} and
+        \texttt{Snapshot2\_Regression\_Report.pdf}.
+  \item Sample input/output files documented.
+\end{itemize}
+
+\subsection{Snapshot 2 Reflection}
+\textit{To be completed at end of Snapshot 2.}\\
+What changed from Snapshot 1: \dots \\
+Risks that materialized: \dots \\
+Risks retired: \dots
+
+%==========================================================
+\section{Snapshot 3 -- Semi-Autonomous Navigation}
+%==========================================================
+\textit{Simulated Months 7--9. Second major technical feature.}
+
+\subsection{Objective}
+Add the second major capability: semi-autonomous navigation for the
+rover. This feature has explicit safety requirements (manual override,
+safe stop) that drive new test cases and additional UI surfaces.
+
+\subsection{Planned Work Items}
+\begin{itemize}[leftmargin=*]
+  \item \textbf{P2-S3-001} Update SRS with GPS waypoint navigation,
+        sequential waypoint execution, obstacle detection, manual
+        override, safe stop, telemetry logging, live position tracking,
+        battery monitoring requirements.
+  \item \textbf{P3-S3-001} Update SDD and workflow diagram with the
+        navigation module: waypoint queue, path planner, obstacle
+        detector, override controller, safe-stop service, telemetry
+        logger.
+  \item \textbf{P4-S3-001} Update Design Spec with navigation
+        dependencies (ROS/ROS Bridge, GPS parsing, optional YOLO for
+        obstacle detection) and add \texttt{nav-service} to Docker
+        compose.
+  \item \textbf{P5-S3-001} Build TestRail Navigation/Safety suite,
+        execute test run, export
+        \texttt{Snapshot3\_TestRun\_Report.pdf}.
+  \item \textbf{P1-S3-001} Sprint retro, update risk register, reflection
+        in this document (Erfan).
+\end{itemize}
+
+\subsection{Definition of Done}
+\begin{itemize}[leftmargin=*]
+  \item All seven Spring 2026 navigation requirements present in SRS.
+  \item SDD module diagram shows navigation flow with safety stop and
+        override paths.
+  \item TestRail Navigation/Safety suite has at least one test per
+        requirement.
+  \item \texttt{Snapshot3\_TestRun\_Report.pdf} committed.
+  \item Workflow diagram v3 reflects new navigation surfaces.
+\end{itemize}
+
+\subsection{Snapshot 3 Reflection}
+\textit{To be completed at end of Snapshot 3.}\\
+Navigation scope landed: \dots \\
+What we cut: \dots \\
+Cross-feature impact (e.g., did navigation force SRS changes?): \dots
+
+%==========================================================
+\section{Snapshot 4 -- Final Submission and Future Work}
+%==========================================================
+\textit{Simulated Months 10--12. Polish, final test reports, future work.}
+
+\subsection{Objective}
+Finalize all documentation, complete the simulated field testing
+narrative, deliver the final TestRail regression report, and produce a
+retrospective and future-work plan. After Snapshot 4 the repository
+must be gradeable in an incognito browser by anyone with the link.
+
+\subsection{Planned Work Items}
+\begin{itemize}[leftmargin=*]
+  \item \textbf{P2-S4-001} Final SRS pass: revision history, completed
+        vs deferred features, future work.
+  \item \textbf{P3-S4-001} Final SDD pass and final workflow diagram.
+  \item \textbf{P4-S4-001} Final Design Spec and Docker docs cleanup;
+        verify \texttt{docker compose config} still passes.
+  \item \textbf{P5-S4-001} Final TestRail regression run, export
+        \texttt{Snapshot4\_Final\_TestRun\_Report.pdf}, run final
+        submission audit checklist.
+  \item \textbf{P1-S4-001} Final reflection, future work section, sign
+        off pre-submission audit (Erfan).
+\end{itemize}
+
+\subsection{Definition of Done}
+\begin{itemize}[leftmargin=*]
+  \item Every item in the pre-submission audit (Section~\ref{sec:audit}) is checked.
+  \item All four TestRail PDFs are in \texttt{Final\_Project/docs/TestRail\_Documents/}.
+  \item Root \texttt{README.md} links every required document.
+  \item Repo cloned anonymously builds via
+        \texttt{docker compose config} and passes.
+  \item Final reflection in this document is complete.
+\end{itemize}
+
+\subsection{Final Reflection}
+\textit{To be completed at end of Snapshot 4.}
+
+\subsubsection*{Completed Features}
+\begin{itemize}[leftmargin=*]
+  \item \dots
+\end{itemize}
+
+\subsubsection*{Incomplete or Deferred Features}
+\begin{itemize}[leftmargin=*]
+  \item \dots
+\end{itemize}
+
+\subsubsection*{Future Work}
+\begin{itemize}[leftmargin=*]
+  \item Cloud-based processing (Azure Blob / S3) for large LiDAR scans.
+  \item Improved LiDAR hardware (dedicated unit vs iPhone LiDAR).
+  \item ROS1 $\rightarrow$ ROS2 migration for navigation stack.
+  \item YOLO-based rover centering on sidewalk during traversal.
+  \item Real-time on-device inference for crack detection.
+\end{itemize}
+
+%==========================================================
+\section{Pre-Submission Audit Checklist}
+\label{sec:audit}
+%==========================================================
+Owned by Erfan Mirzaee. Must be 100\% checked before final push.
+
+\begin{itemize}[leftmargin=*]
+  \item[$\square$] Root \texttt{README.md} explains the project and links every required document.
+  \item[$\square$] \texttt{README\_User\_Manual.tex} contains the live Jira link.
+  \item[$\square$] All required documents exist as \texttt{.tex} files (not \texttt{.docx}).
+  \item[$\square$] Snapshot Objectives \texttt{.tex} contains all four snapshots with reflections.
+  \item[$\square$] SDD and SRS revision tables show updates for each of the four snapshots.
+  \item[$\square$] Four TestRail PDFs are in \texttt{Final\_Project/docs/TestRail\_Documents/}.
+  \item[$\square$] Workflow diagram in \texttt{Final\_Project/docs/Workflow\_Diagram/} as PNG plus editable source.
+  \item[$\square$] \texttt{Final\_Project/docker/docker-compose.yml} exists and is explained in the Design Spec.
+  \item[$\square$] Every team member has visible commits, Jira tickets, or documented ownership.
+  \item[$\square$] Final repo URL tested in an incognito browser by another teammate.
+\end{itemize}
+
+\end{document}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,91 @@
+# CS 3338 Final Project — LA City Sidewalk Assessment Simulation
+
+**Group 5** | California State University, Northridge
+
+> A simulated 12-month software development timeline for a rover-based
+> sidewalk inspection system supporting LA City Bureau of Engineering
+> ADA compliance assessment.
+
+---
+
+## Project Links
+
+| Resource | URL |
+|---|---|
+| GitHub | https://github.com/dar-ienn/CS3338-final-project |
+| Jira (Scrum) | https://cs3338-group-5-final-project.atlassian.net/jira/software/projects/SCRUM/boards/1/backlog |
+| TestRail | https://ercs3338group5.testrail.io |
+
+## Team & Roles
+
+| Name | Role | Owns |
+|---|---|---|
+| Erfan Mirzaee | Project Manager | Repo structure, Jira, `Snapshot_Objectives.tex`, audit |
+| James Barron | Requirements Lead | `SRS.tex` |
+| Elijah Rodriguez | Architecture Lead | `SDD.tex`, workflow diagram |
+| Andrew | Technical Lead | `Design_Spec.tex`, Docker |
+| Darien Amador | QA Lead | `README_User_Manual.tex`, TestRail reports |
+
+## Repository Layout
+
+All deliverables live under `Final_Project/` (the wrapper established during the prerequisite lab).
+
+```
+Final_Project/
+├── docs/
+│   ├── Snapshot_Objectives/           # Snapshot_Objectives.tex (Erfan)
+│   ├── Software_Requirement_Specifications/  # SRS.tex (James)
+│   ├── Software_Design_Document/      # SDD.tex (Elijah)
+│   ├── User_Manual/                   # README_User_Manual.tex (Darien)
+│   ├── Workflow_Diagram/              # PNG + editable source (Elijah)
+│   └── TestRail_Documents/            # 4 PDF reports (Darien)
+├── admin/                             # Risk register, meeting notes (Erfan)
+├── docker/                            # docker-compose.yml (Andrew)
+├── src/                               # Code placeholders
+└── assets/                            # Images, test files
+```
+
+## Required Documents
+
+| Document | Path | Owner |
+|---|---|---|
+| Snapshot Objectives | [`Final_Project/docs/Snapshot_Objectives/Snapshot_Objectives.tex`](Final_Project/docs/Snapshot_Objectives/Snapshot_Objectives.tex) | Erfan |
+| Software Requirements Specification | `Final_Project/docs/Software_Requirement_Specifications/SRS.tex` | James |
+| Software Design Document | `Final_Project/docs/Software_Design_Document/SDD.tex` | Elijah |
+| README / User Manual | `Final_Project/docs/User_Manual/README_User_Manual.tex` | Darien |
+| Design Specification | `Final_Project/docs/Design_Spec/Design_Spec.tex` | Andrew |
+| Workflow Diagram | `Final_Project/docs/Workflow_Diagram/` | Elijah |
+| TestRail Reports (×4) | `Final_Project/docs/TestRail_Documents/` | Darien |
+| Docker Compose | `Final_Project/docker/docker-compose.yml` | Andrew |
+
+## Snapshot Schedule
+
+| Snapshot | Sim. Months | Theme | Definition of Done |
+|---|---|---|---|
+| 1 | 1–3 | Project foundation | Skeleton docs, Jira live, Docker stub validates |
+| 2 | 4–6 | Data processing & displacement pipeline | SRS/SDD updated; TestRail S2 reports committed |
+| 3 | 7–9 | Semi-autonomous navigation | Navigation reqs/design; safety tests pass |
+| 4 | 10–12 | Final submission | All docs final; 4 TestRail PDFs; audit signed off |
+
+## Quick Start
+
+```bash
+git clone https://github.com/dar-ienn/CS3338-final-project.git
+cd CS3338-final-project
+```
+
+To validate the Docker plan (once `docker-compose.yml` is in place):
+```bash
+cd Final_Project/docker && docker compose config
+```
+
+## Branching Convention
+
+- `main` is protected. No direct commits.
+- Personal branches: `<name>/<scope>-snapshot<N>`, e.g., `erfan/repo-setup-snapshot1`.
+- Commit prefix: `snapshot<N>:`, e.g., `snapshot1: add snapshot objectives`.
+- All work merges via Pull Request with at least one reviewer.
+
+## License
+
+Academic project — CSUN CS 3338.


### PR DESCRIPTION
Completes **P1-S1-001, P1-S1-002, P1-S1-003, P1-S1-004**.

## Snapshot 1 PM deliverables in this PR

- `README.md` at repo root — project index, links Jira/TestRail/GitHub, lists all required documents and owners
- `Final_Project/docs/Snapshot_Objectives/Snapshot_Objectives.tex` — covers all four snapshots with objectives, planned work, definition of done, reflections, and a pre-submission audit checklist
- `Final_Project/admin/risk_register.md` — 12 baseline risks with owners and mitigations
- `Final_Project/admin/meeting_notes/TEMPLATE.md` — reusable template for standups/planning/retros
- `.gitignore` fix — the previous `.gitignore` excluded `docs/User_Manual/` which is one of our required deliverables

## ⚠️ Heads-up for the team — please read before approving

The assignment requires `.tex` (LaTeX) files, but our existing skeleton has empty `.docx` placeholders for SRS, SDD, and TestRail docs. Each doc owner needs to add a `.tex` file alongside (or replace) their `.docx`:

- **James** → `Final_Project/docs/Software_Requirement_Specifications/SRS.tex`
- **Elijah** → `Final_Project/docs/Software_Design_Document/SDD.tex`
- **Darien** → `Final_Project/docs/User_Manual/README_User_Manual.tex`
- **Andrew** → `Final_Project/docs/Design_Spec/Design_Spec.tex` (new folder needed)

I added this to the risk register as **R-11**. Will discuss at sprint planning.

## Topic confirmed

We're going with **LA City Sidewalk Assessment** (one of the three Ascent topics). Reasoning is documented in `Snapshot_Objectives.tex` — broadest technical surface (ML + LiDAR + robotics + full-stack) means the strongest resume bullets for everyone.

## Review request

@drew990 @dar-ienn  @jamesbarron17   @ZomCie   — please review and approve. Once one of you approves, I'll merge.